### PR TITLE
Add arbitrum to docs

### DIFF
--- a/pages/_meta.en.json
+++ b/pages/_meta.en.json
@@ -18,8 +18,13 @@
     "newWindow": true
   },
   "coingecko_link": {
-    "title": "CoinGecko  ↗",
+    "title": "CoinGecko EGGS ↗",
     "href": "  https://www.coingecko.com/en/coins/eggs",
+    "newWindow": true
+  },
+  "coingecko_link_aeggs": {
+    "title": "CoinGecko aEGGS ↗",
+    "href": "  https://www.coingecko.com/en/coins/aeggs",
     "newWindow": true
   },
   "telegram_link": {

--- a/pages/_meta.zh.json
+++ b/pages/_meta.zh.json
@@ -13,8 +13,13 @@
     "newWindow": true
   },
   "coingecko_link": {
-    "title": "CoinGecko  ↗",
+    "title": "CoinGecko EGGS ↗",
     "href": "https://www.coingecko.com/zh/%E6%95%B0%E5%AD%97%E8%B4%A7%E5%B8%81/eggs",
+    "newWindow": true
+  },
+  "coingecko_link_aeggs": {
+    "title": "CoinGecko aEGGS ↗",
+    "href": "  https://www.coingecko.com/en/coins/aeggs",
     "newWindow": true
   },
   "telegram_link": {

--- a/pages/index.en.mdx
+++ b/pages/index.en.mdx
@@ -1,30 +1,31 @@
 # What is Eggs? 🥚
 
 EGGS is an eggsperiment in decentralized finance.
-The evil Egg Cartel are going rampage around the world stealing precious EGGS.
-This has grave consequences and the EGGS supply is getting debased (decreasing) by 0.001% every block which is around 7% per day.
+The evil Egg Cartel are running rampage around the world stealing precious EGGS. Hence, the EGGS supply is getting debased every block.
 
-#### What consequences does this have?
+Currently EGGS exist on two networks:
+- Ethereum Mainnet [$EGGS](https://www.coingecko.com/en/coins/eggs)
+- Arbitrum [$aEGGS](https://www.coingecko.com/en/coins/aeggs)
 
-The rebase era is over but EGGS will spike a new revolution with debase tokens.
-The debase will increase the value of your EGGS automatically if noone are selling.
-How is that possible? Remember that debase also affects LP. So less EGGS in LP over time but same amount of ETH.
+#### What consequences does the debase have?
+
+The rebase era is over, and EGGS will spike a new revolution with debase tokens.
+The debase will increase the value of your EGGS automatically if noone is selling.
+How is that possible? Debase affects the EGGS that are in LP, therefore the number of EGGS in LP will decrease over time while the amount of ETH remains constant.
 
 If you understand this concept you have been egg-pilled.
 
 ## How do we protec our EGGS?
 
-You can protect your EGGS by depositing into secure vaults. There are three types of vaults.
-Full, big and smol protect vaults.
-Full protec vault will protect your precious eggs FULLY and won't be affected by debase.
-Full protec vault has a locking period of 7 days on deposit and partial withdrawals.
-No relocks required.
+You can protect your EGGS by locking them in secure vaults.
+Once they have been locked, they will not need to be re-locked at the end of the minimum locking period.
 
-The other two vaults only protect your EGGS partially in the form of rewards.
-The rewards are 10 million EGGS per block. Big protec vault earns you 9/10 of the rewards by staking EGGS/ETH LP on Uniswap V2.
-The smol protec vault earns you only 1/10 of the rewards. Both of these vaults only have a locking period of 24 hours.
+| Vault Name | Minimum Locking Period | % Of Rewards | Eggs will debase |
+| :--------: | :--------------------: | :----------: | :--------------: |
+| Full       |         7 days         |  None        | False            |
+| Big        |         1 day          |  90%         | True             |
+| Smol       |         1 day          |  10%         | True             |
 
-Depositing your EGGS in either vaults will lock them for 24 hours.
-Claiming rewards will reset timer and lock for another 24 hours.
+Claiming rewards from Big or Smol will reset the timer and lock for another 24 hours.
 Depositing or claiming will NOT extend your locking period further.
 Partial withdrawals will NOT lock for these two types of vaults.

--- a/pages/tokenomics.en.mdx
+++ b/pages/tokenomics.en.mdx
@@ -1,21 +1,23 @@
 # Tokenomics
 
-- Initial Supply: 3,324,324,324,357
-- Burned: ~931,616,056,878
-- Current supply: less than ~2,000,000,000,000 (decreasing every block)
-- Dev has burned all his LP tokens and most of the current liquidity is now community owned.
+| Token Name | Network          | Initial Supply      | Debase Rate (per block)  | Rewards (per block) |
+| :--------: | :--------------: | :-----------------: | :----------------------: | :---------------:   |
+| EGGS       | Ethereum Mainnet |  3,324,324,324,357  |  0.001%                  | 10 million          |
+| aEGGS      | Arbitrum         |  3,324,324,324,357  |  0.002%                  | 20 million          |
 
-EGGS started as a LBP on Copper/Fjord to get a fair price and distribution of tokens.
+$EGGS started as an LBP on Copper/Fjord to get a fair price and distribution of tokens.
 Link to LBP [here](https://fjordfoundry.com/pools/mainnet/0x04EEECa0d37a238B46DeD385F04F956F6D9656A2).
 LBP managed to accrue around 188.78 ETH.
 Dev exited LBP and used 185 ETH and 175,000,000,000 EGGS to create an Uniswap V2 pool. Setting the price just below final LBP price.
 Some time after dev burned all his LP tokens. Most of the liquidity you see now is community owned.
 
-### Mechanics
+## Rewards
 
-EGGS are getting debased every block with a 0.001% rate which is around 7% a day.
-To compensate a little for this decrease you can stake your tokens in either Big or Smol vaults and get rewards.
-Rewards will only get debased upon claim! Rewards are currently set to 10,000,000 EGGS per block.
+If you stake your tokens in either Big or Smol vaults, you will receive rewards for each block. 
+The table above shows how many rewards in total will be distributed per block. 
+All rewards you receive will not start to debase, until you claim them.
+
+To see what % of rewards go to Big and Smol, please refer to the vaults table.
 Rewards can be changed by dev and is subject to change.
 
 Depositing or claiming will incur 24 hours lock on withdrawals.
@@ -26,10 +28,13 @@ That's the beauty of it since the price of EGGS will continue to increase if noo
 
 ## Contracts
 
+### EGGS
 EGGS token has a mint function but the owner is a Timelock contract which has been set to 3 days.
 So everyone has time to react for 3 days if dev does something.
-
 - [EGGS Token Contract](https://etherscan.io/token/0x2e516ba5bf3b7ee47fb99b09eadb60bde80a82e0)
 - [EggChef Farm Contract](https://etherscan.io/address/0xfc6a933a32aa6a382ea06d699a8b788a0bc49fcb)
 - [Full Protect Contract](https://etherscan.io/address/0x98d9f08824798d7fd37bd0dd740069baf31c37e7)
 - [Timelock Contract](https://etherscan.io/address/0x70dcd5cafdfc982bccafa97091f6bca29859149a)
+
+### aEGGS
+- [aEGGS Token Contract](https://arbiscan.io/token/0x2e516ba5bf3b7ee47fb99b09eadb60bde80a82e0)


### PR DESCRIPTION
## Separating Tokenomics
The new Arbitrum network token aEGGS has slightly different tokenomics to mainnet - see new table below:

<img width="424" alt="Screenshot 2023-03-28 at 09 20 28" src="https://user-images.githubusercontent.com/74299201/228174576-104dc047-b6b7-45d8-858f-ec3a40d1116c.png">

## Making vaults easier to understand
I have added a table to make the vaults easier to understand/compare:

<img width="428" alt="Screenshot 2023-03-28 at 09 20 17" src="https://user-images.githubusercontent.com/74299201/228174584-300f714b-038e-45a2-9f12-fa35eb3a9218.png">
